### PR TITLE
made Environment a subclass of IDictionary<string, object>

### DIFF
--- a/src/Gate/Environment.cs
+++ b/src/Gate/Environment.cs
@@ -16,7 +16,7 @@ namespace Gate
     /// Utility class providing strongly-typed get/set access to environment properties 
     /// defined by the OWIN spec.
     /// </summary>
-    public class Environment
+    public class Environment : Dictionary<string, object>
     {
         public static readonly string RequestMethodKey = "owin.RequestMethod";
         public static readonly string RequestPathBaseKey = "owin.RequestPathBase";
@@ -27,18 +27,20 @@ namespace Gate
         public static readonly string RequestSchemeKey = "owin.RequestScheme";
         public static readonly string VersionKey = "owin.Version";
 
-        protected readonly IDictionary<string, object> Env;
-
 
         protected T Get<T>(string name)
         {
             object value;
-            return Env.TryGetValue(name, out value) ? (T) value : default(T);
+            return TryGetValue(name, out value) ? (T) value : default(T);
         }
 
+        public Environment() { }
         public Environment(IDictionary<string, object> env)
         {
-            Env = env;
+            foreach (var pair in env)
+            {
+                this[pair.Key] = pair.Value;
+            }
         }
 
         /// <summary>
@@ -47,7 +49,7 @@ namespace Gate
         public string Version
         {
             get { return Get<string>(VersionKey); }
-            set { Env[VersionKey] = value; }
+            set { this[VersionKey] = value; }
         }
 
         /// <summary>
@@ -56,7 +58,7 @@ namespace Gate
         public string Method
         {
             get { return Get<string>(RequestMethodKey); }
-            set { Env[RequestMethodKey] = value; }
+            set { this[RequestMethodKey] = value; }
         }
 
         /// <summary>
@@ -65,7 +67,7 @@ namespace Gate
         public IDictionary<string, string> Headers
         {
             get { return Get<IDictionary<string, string>>(RequestHeadersKey); }
-            set { Env[RequestHeadersKey] = value; }
+            set { this[RequestHeadersKey] = value; }
         }
 
         /// <summary>
@@ -74,7 +76,7 @@ namespace Gate
         public string PathBase
         {
             get { return Get<string>(RequestPathBaseKey); }
-            set { Env[RequestPathBaseKey] = value; }
+            set { this[RequestPathBaseKey] = value; }
         }
 
         /// <summary>
@@ -83,7 +85,7 @@ namespace Gate
         public string Path
         {
             get { return Get<string>(RequestPathKey); }
-            set { Env[RequestPathKey] = value; }
+            set { this[RequestPathKey] = value; }
         }
 
         /// <summary>
@@ -92,7 +94,7 @@ namespace Gate
         public string Scheme
         {
             get { return Get<string>(RequestSchemeKey); }
-            set { Env[RequestSchemeKey] = value; }
+            set { this[RequestSchemeKey] = value; }
         }
 
         /// <summary>
@@ -101,7 +103,7 @@ namespace Gate
         public BodyAction Body
         {
             get { return Get<BodyAction>(RequestBodyKey); }
-            set { Env[RequestBodyKey] = value; }
+            set { this[RequestBodyKey] = value; }
         }
 
         /// <summary>
@@ -110,7 +112,7 @@ namespace Gate
         public string QueryString
         {
             get { return Get<string>(RequestQueryStringKey); }
-            set { Env[RequestQueryStringKey] = value; }
+            set { this[RequestQueryStringKey] = value; }
         }
     }
 }

--- a/src/Gate/Request.cs
+++ b/src/Gate/Request.cs
@@ -10,6 +10,7 @@ namespace Gate
     {
         static readonly char[] CommaSemicolon = new[] {',', ';'};
 
+        public Request() : base() { }
         public Request(IDictionary<string, object> env) : base(env)
         {
         }
@@ -22,8 +23,8 @@ namespace Gate
                 if (Get<string>("Gate.Helpers.Request.Query:text") != text ||
                     Get<IDictionary<string, string>>("Gate.Helpers.Request.Query") == null)
                 {
-                    Env["Gate.Helpers.Request.Query:text"] = text;
-                    Env["Gate.Helpers.Request.Query"] = ParamDictionary.Parse(text);
+                    this["Gate.Helpers.Request.Query:text"] = text;
+                    this["Gate.Helpers.Request.Query"] = ParamDictionary.Parse(text);
                 }
                 return Get<IDictionary<string, string>>("Gate.Helpers.Request.Query");
             }
@@ -89,9 +90,9 @@ namespace Gate
                         Get<IDictionary<string, string>>("Gate.Helpers.Request.Post") == null)
                     {
                         var text = input.ToText(Encoding.UTF8);
-                        Env["Gate.Helpers.Request.Post:input"] = input;
-                        Env["Gate.Helpers.Request.Post:text"] = text;
-                        Env["Gate.Helpers.Request.Post"] = ParamDictionary.Parse(text);
+                        this["Gate.Helpers.Request.Post:input"] = input;
+                        this["Gate.Helpers.Request.Post:text"] = text;
+                        this["Gate.Helpers.Request.Post"] = ParamDictionary.Parse(text);
                     }
                     return Get<IDictionary<string, string>>("Gate.Helpers.Request.Post");
                 }

--- a/src/Gate/UrlMapper.cs
+++ b/src/Gate/UrlMapper.cs
@@ -37,17 +37,17 @@ namespace Gate
         }
 
         public void Call(
-            IDictionary<string, object> env,
+            IDictionary<string, object> envDict,
             ResultDelegate result,
             Action<Exception> fault)
         {
-            var owin = new Environment(env);
-            var path = owin.Path;
-            var pathBase = owin.PathBase;
+            var env = envDict as Environment ?? new Environment(envDict);
+            var path = env.Path;
+            var pathBase = env.PathBase;
             Action finish = () =>
             {
-                owin.Path = path;
-                owin.PathBase = pathBase;
+                env.Path = path;
+                env.PathBase = pathBase;
             };
             var match = _map.FirstOrDefault(m => path.StartsWith(m.Item1));
             if (match == null)
@@ -56,8 +56,8 @@ namespace Gate
                 _app(env, result, fault);
                 return;
             }
-            owin.PathBase = pathBase + match.Item1;
-            owin.Path = path.Substring(match.Item1.Length);
+            env.PathBase = pathBase + match.Item1;
+            env.Path = path.Substring(match.Item1.Length);
             match.Item2.Invoke(env, result, fault);
         }
     }

--- a/src/Hosts/Gate.AspNet/AppHandler.cs
+++ b/src/Hosts/Gate.AspNet/AppHandler.cs
@@ -36,12 +36,10 @@ namespace Gate.AspNet
             if (path.StartsWith(pathBase))
                 path = path.Substring(pathBase.Length);
 
-            var env = new Dictionary<string, object>();
-
             var requestHeaders = httpRequest.Headers.AllKeys
                 .ToDictionary(x => x, x => httpRequest.Headers.Get(x), StringComparer.OrdinalIgnoreCase);
 
-            new Environment(env)
+            var env = new Environment()
             {
                 Version = "1.0",
                 Method = httpRequest.HttpMethod,
@@ -89,6 +87,8 @@ namespace Gate.AspNet
         public void EndProcessRequest(IAsyncResult asyncResult)
         {
             var task = ((Task<Action>) asyncResult);
+            // XXX should wait for task? seems to be a race.
+            //task.Wait();
             if (task.IsFaulted)
             {
                 var exception = task.Exception;

--- a/src/Tests/Gate.Helpers.Tests/RewindableBodyTests.cs
+++ b/src/Tests/Gate.Helpers.Tests/RewindableBodyTests.cs
@@ -62,7 +62,7 @@ namespace Gate.Helpers.Tests
             BodyDelegate body = (next, error, complete) =>
             {
                 ++bodyCallCount;
-                foreach (var line in Enumerable.Range(0, 40000))
+                foreach (var line in Enumerable.Range(0, 4000))
                 {
                     var bytes = Encoding.UTF8.GetBytes("Hello line " + line);
                     totalBytes += bytes.Length;

--- a/src/Tests/Gate.TestHelpers/FakeHost.cs
+++ b/src/Tests/Gate.TestHelpers/FakeHost.cs
@@ -43,9 +43,7 @@ namespace Gate.TestHelpers
 
         FakeHostResponse Invoke(Action<FakeHostRequest> requestSetup)
         {
-            var env = new Dictionary<string, object>();
-
-            var request = new FakeHostRequest(env)
+            var request = new FakeHostRequest()
             {
                 Version = "1.0",
                 Scheme = "http",
@@ -56,7 +54,7 @@ namespace Gate.TestHelpers
             var wait = new ManualResetEvent(false);
             var response = new FakeHostResponse();
             _app(
-                env,
+                request,
                 (status, headers, body) =>
                 {
                     response.Status = status;

--- a/src/Tests/Gate.TestHelpers/FakeHostRequest.cs
+++ b/src/Tests/Gate.TestHelpers/FakeHostRequest.cs
@@ -4,6 +4,7 @@ namespace Gate.TestHelpers
 {
     public class FakeHostRequest : Environment
     {
+        public FakeHostRequest() : base() { }
         public FakeHostRequest(IDictionary<string, object> env) : base(env)
         {
         }

--- a/src/Tests/Gate.Tests/EnvironmentTests.cs
+++ b/src/Tests/Gate.Tests/EnvironmentTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 namespace Gate.Tests
 {
     [TestFixture]
-    public class OwinTests
+    public class EnvironmentTests
     {
         [Test]
         public void Version_property_provide_access_to_environment()
@@ -17,19 +17,18 @@ namespace Gate.Tests
         }
 
         [Test]
-        public void Envoronment_access_is_not_buffered_or_cached()
+        public void Environment_access_is_not_buffered_or_cached()
         {
-            var env = new Dictionary<string, object> {{"owin.Version", "1.0"}};
-            var environment = new Environment(env);
+            var environment = new Environment() {{"owin.Version", "1.0"}};
             Assert.That(environment.Version, Is.EqualTo("1.0"));
 
-            env["owin.Version"] = "1.1";
+            environment["owin.Version"] = "1.1";
             Assert.That(environment.Version, Is.EqualTo("1.1"));
 
-            env["owin.Version"] = null;
+            environment["owin.Version"] = null;
             Assert.That(environment.Version, Is.Null);
 
-            env.Remove("owin.Version");
+            environment.Remove("owin.Version");
             Assert.That(environment.Version, Is.Null);
         }
 
@@ -68,8 +67,7 @@ namespace Gate.Tests
             var headers = new Dictionary<string, string>();
             var body = new BodyDelegate((next, error, complete) => () => { }).ToAction();
 
-            var env = new Dictionary<string, object>();
-            var environment = new Environment(env)
+            var environment = new Environment()
             {
                 Method = "GET",
                 Path = "/foo",
@@ -80,6 +78,7 @@ namespace Gate.Tests
                 Scheme = "https",
                 Version = "1.0"
             };
+            IDictionary<string, object> env = environment;
 
             Assert.That(environment.Method, Is.EqualTo("GET"));
             Assert.That(environment.Path, Is.EqualTo("/foo"));

--- a/src/Tests/Gate.Tests/RequestTests.cs
+++ b/src/Tests/Gate.Tests/RequestTests.cs
@@ -11,46 +11,34 @@ namespace Gate.Tests
         [Test]
         public void QueryString_is_used_to_populate_Query_dictionary()
         {
-            var env = new Dictionary<string, object>();
-            new Environment(env) {QueryString = "foo=bar"};
-
-            var request = new Request(env);
+            var request = new Request() { QueryString = "foo=bar" };
             Assert.That(request.Query["foo"], Is.EqualTo("bar"));
         }
 
         [Test]
         public void Changing_QueryString_in_environment_reparses_Query_dictionary()
         {
-            var env = new Dictionary<string, object>();
-            new Environment(env) {QueryString = "foo=bar"};
-
-            var request = new Request(env);
+            var request = new Request() { QueryString = "foo=bar" };
             Assert.That(request.Query["foo"], Is.EqualTo("bar"));
 
-            new Environment(env) {QueryString = "foo=quux"};
+            request.QueryString = "foo=quux";
             Assert.That(request.Query["foo"], Is.EqualTo("quux"));
         }
 
         [Test]
         public void Body_is_used_to_populate_Post_dictionary()
         {
-            var env = new Dictionary<string, object>();
-            new Environment(env) {Method = "POST", Body = Body.FromText("foo=bar")};
-
-            var request = new Request(env);
+            var request = new Request() {Method = "POST", Body = Body.FromText("foo=bar")};
             Assert.That(request.Post["foo"], Is.EqualTo("bar"));
         }
 
         [Test]
         public void Changing_Body_in_environment_reparses_Post_dictionary()
         {
-            var env = new Dictionary<string, object>();
-            new Environment(env) {Method = "POST", Body = Body.FromText("foo=bar")};
-
-            var request = new Request(env);
+            var request = new Request() {Method = "POST", Body = Body.FromText("foo=bar")};
             Assert.That(request.Post["foo"], Is.EqualTo("bar"));
 
-            new Environment(env) {Body = Body.FromText("foo=quux")};
+            request.Body = Body.FromText("foo=quux");
             Assert.That(request.Post["foo"], Is.EqualTo("quux"));
         }
 


### PR DESCRIPTION
Environment class extends from IDictionary. Host handlers could allocate it once (like they would with the dict) and pass it on. Middlewares which want to use an Environment instance do a simple check like: 

```
var env = env as Environment ?? new Environment(envDict);
```

Previously a new Environment object had to be created to wrap the context at every middleware that wants to use it—now the stack is spared these extra allocations.
