### PR TITLE
Ideas for pulling remote host and proxied hosts off of X-Forwarded-For only

### DIFF
--- a/src/Gate.Middleware/Gate.Middleware.csproj
+++ b/src/Gate.Middleware/Gate.Middleware.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Cascade.cs" />
     <Compile Include="ContentType.cs" />
     <Compile Include="RewindableBody.cs" />
+    <Compile Include="XForwardedFor.cs" />
     <Compile Include="ShowExceptions.cs" />
     <Compile Include="ShowExceptions.View.cs">
       <AutoGen>True</AutoGen>

--- a/src/Gate.Middleware/XForwardedFor.cs
+++ b/src/Gate.Middleware/XForwardedFor.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Gate
 {
-	public static class XForwardedFor
+    public static class XForwardedFor
     {
         static readonly string[] empty = new[] { "" };
 
@@ -28,14 +28,14 @@ namespace Gate
             return env.GetRemoteHosts().LastOrDefault();
         }
 
-        public static IEnumerable<string> GetRemoteAddresses(this IDictionary<string, object> env)
+        public static IEnumerable<string> GetProxiedAddresses(this IDictionary<string, object> env)
         {
             return env.GetRemoteHosts().Reverse().Skip(1).Reverse();
         }
 
-        public static IEnumerable<string> GetRemoteAddresses(this IDictionary<string, object> env, params string[] knownProxies)
+        public static IEnumerable<string> GetProxiedAddresses(this IDictionary<string, object> env, params string[] knownProxies)
         {
-            return env.GetRemoteAddresses().Reverse().SkipWhile(s => knownProxies.Contains(s)).Reverse();
+            return env.GetProxiedAddresses().Reverse().SkipWhile(s => knownProxies.Contains(s)).Reverse();
         }
 	}
 }

--- a/src/Gate.Middleware/XForwardedFor.cs
+++ b/src/Gate.Middleware/XForwardedFor.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Gate
+{
+	public static class XForwardedFor
+    {
+        static readonly string[] empty = new[] { "" };
+
+        static IEnumerable<string> GetRemoteHosts(this IDictionary<string, object> env)
+        {
+            var headers = (env as Gate.Environment ?? new Gate.Environment(env)).Headers;
+
+            if (headers == null)
+                return empty;
+
+            var xff = headers.ContainsKey("x-forwarded-for") ? headers["x-forwarded-for"] : null;
+
+            if (string.IsNullOrWhiteSpace(xff))
+                return empty;
+
+            return xff.Split(',').Select(s => s.Trim()).Where(s => !string.IsNullOrEmpty(s)).ToArray();
+        }
+
+        public static string GetRemoteAddress(this IDictionary<string, object> env)
+        {
+            return env.GetRemoteHosts().LastOrDefault();
+        }
+
+        public static IEnumerable<string> GetRemoteAddresses(this IDictionary<string, object> env)
+        {
+            return env.GetRemoteHosts().Reverse().Skip(1).Reverse();
+        }
+
+        public static IEnumerable<string> GetRemoteAddresses(this IDictionary<string, object> env, params string[] knownProxies)
+        {
+            return env.GetRemoteAddresses().Reverse().SkipWhile(s => knownProxies.Contains(s)).Reverse();
+        }
+	}
+}

--- a/src/Tests/Gate.Middleware.Tests/Gate.Middleware.Tests.csproj
+++ b/src/Tests/Gate.Middleware.Tests/Gate.Middleware.Tests.csproj
@@ -72,5 +72,6 @@
     <Compile Include="ContentTypeTests.cs" />
     <Compile Include="RewindableBodyTests.cs" />
     <Compile Include="ShowExceptionsTests.cs" />
+    <Compile Include="XForwardedForTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Gate.Middleware.Tests/XForwardedForTests.cs
+++ b/src/Tests/Gate.Middleware.Tests/XForwardedForTests.cs
@@ -1,0 +1,128 @@
+using System;
+using NUnit;
+using System.Collections.Generic;
+using Gate;
+using NUnit.Framework;
+using System.Linq;
+
+namespace Gate.Middleware.Tests
+{
+    [TestFixture]
+    public class XForwardedForTests
+    {
+        IDictionary<string, object> dict;
+     
+        [SetUp]
+        public void SetUp()
+        {
+            dict = new Dictionary<string, object>();
+        }
+     
+        public void SetXFF(string xForwardedFor)
+        {
+            new Environment(dict).Headers = new Dictionary<string, string>() { { "x-forwarded-for", xForwardedFor } };
+        }
+
+        [Test]
+        public void Remote_address_is_empty_if_no_xff()
+        {
+            var host = dict.GetRemoteAddress();
+            Assert.That(host, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void Remote_address_is_empty_if_empty_xff()
+        {
+            SetXFF("");
+            var host = dict.GetRemoteAddress();
+            Assert.That(host, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void Remote_address_is_single_xff_value()
+        {
+            SetXFF("4.4.4.4");
+            var host = dict.GetRemoteAddress();
+            Assert.That(host, Is.EqualTo("4.4.4.4"));
+        }
+
+        [Test]
+        public void Remote_address_is_right_most_value()
+        {
+            SetXFF("1.2.3.4, 4.4.4.4");
+            var host = dict.GetRemoteAddress();
+            Assert.That(host, Is.EqualTo("4.4.4.4"));
+        }
+
+        [Test]
+        public void Remote_addresses_are_empty_if_no_xff()
+        {
+            var host = dict.GetRemoteAddresses();
+            Assert.That(host, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void Remote_addresses_are_empty_if_empty_xff()
+        {
+            SetXFF("");
+            var host = dict.GetRemoteAddresses();
+            Assert.That(host, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void Remote_addresses_are_empty_if_single_xff()
+        {
+            SetXFF("4.4.4.4");
+            var host = dict.GetRemoteAddresses();
+            Assert.That(host, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void Remote_addresses_is_left_most_value()
+        {
+            SetXFF("1.2.3.4, 4.4.4.4");
+            var host = dict.GetRemoteAddresses();
+            Assert.That(host, Is.EqualTo(new [] { "1.2.3.4" }));
+        }
+
+        [Test]
+        public void Remote_addresses_are_left_most_values()
+        {
+            SetXFF("4.3.2.1, 1.2.3.4, 4.4.4.4");
+            var host = dict.GetRemoteAddresses();
+            Assert.That(host, Is.EqualTo(new[] { "4.3.2.1", "1.2.3.4" }));
+        }
+
+        [Test]
+        public void Remote_addresses_skips_known_proxies()
+        {
+            SetXFF("4.3.2.1, 1.2.3.4, 4.4.4.4");
+            var host = dict.GetRemoteAddresses("1.2.3.4");
+            Assert.That(host, Is.EqualTo(new[] { "4.3.2.1" }));
+        }
+
+        [Test]
+        public void Remote_addresses_skips_multiple_known_proxies()
+        {
+            SetXFF("4.3.2.1, 5.5.5.5, 1.2.3.4, 4.4.4.4");
+            var host = dict.GetRemoteAddresses("1.2.3.4", "5.5.5.5");
+            Assert.That(host, Is.EqualTo(new[] { "4.3.2.1" }));
+        }
+
+        [Test]
+        public void Remote_addresses_skips_known_proxies_and_returns_multiple_unknown_hops()
+        {
+            SetXFF("1.1.1.1, 4.3.2.1, 1.2.3.4, 4.4.4.4");
+            var host = dict.GetRemoteAddresses("1.2.3.4");
+            Assert.That(host, Is.EqualTo(new[] { "1.1.1.1", "4.3.2.1" }));
+        }
+
+        [Test]
+        public void Remote_addresses_skips_multiple_known_proxies_and_returns_multiple_unknown_hops()
+        {
+            SetXFF("1.1.1.1, 4.3.2.1, 5.5.5.5, 1.2.3.4, 4.4.4.4");
+            var host = dict.GetRemoteAddresses("1.2.3.4", "5.5.5.5");
+            Assert.That(host, Is.EqualTo(new[] { "1.1.1.1", "4.3.2.1" }));
+        }
+    }
+}

--- a/src/Tests/Gate.Middleware.Tests/XForwardedForTests.cs
+++ b/src/Tests/Gate.Middleware.Tests/XForwardedForTests.cs
@@ -55,74 +55,82 @@ namespace Gate.Middleware.Tests
         }
 
         [Test]
-        public void Remote_addresses_are_empty_if_no_xff()
+        public void Proxied_addresses_are_empty_if_no_xff()
         {
-            var host = dict.GetRemoteAddresses();
+            var host = dict.GetProxiedAddresses();
             Assert.That(host, Is.EqualTo(""));
         }
 
         [Test]
-        public void Remote_addresses_are_empty_if_empty_xff()
+        public void Proxied_addresses_are_empty_if_empty_xff()
         {
             SetXFF("");
-            var host = dict.GetRemoteAddresses();
+            var host = dict.GetProxiedAddresses();
             Assert.That(host, Is.EqualTo(""));
         }
 
         [Test]
-        public void Remote_addresses_are_empty_if_single_xff()
+        public void Proxied_addresses_are_empty_if_single_xff()
         {
             SetXFF("4.4.4.4");
-            var host = dict.GetRemoteAddresses();
+            var host = dict.GetProxiedAddresses();
             Assert.That(host, Is.EqualTo(""));
         }
 
         [Test]
-        public void Remote_addresses_is_left_most_value()
+        public void Proxied_addresses_is_left_most_value()
         {
             SetXFF("1.2.3.4, 4.4.4.4");
-            var host = dict.GetRemoteAddresses();
+            var host = dict.GetProxiedAddresses();
             Assert.That(host, Is.EqualTo(new [] { "1.2.3.4" }));
         }
 
         [Test]
-        public void Remote_addresses_are_left_most_values()
+        public void Proxied_addresses_are_left_most_values()
         {
             SetXFF("4.3.2.1, 1.2.3.4, 4.4.4.4");
-            var host = dict.GetRemoteAddresses();
+            var host = dict.GetProxiedAddresses();
             Assert.That(host, Is.EqualTo(new[] { "4.3.2.1", "1.2.3.4" }));
         }
 
         [Test]
-        public void Remote_addresses_skips_known_proxies()
+        public void Proxied_addresses_skips_known_proxies()
         {
             SetXFF("4.3.2.1, 1.2.3.4, 4.4.4.4");
-            var host = dict.GetRemoteAddresses("1.2.3.4");
+            var host = dict.GetProxiedAddresses("1.2.3.4");
             Assert.That(host, Is.EqualTo(new[] { "4.3.2.1" }));
         }
 
         [Test]
-        public void Remote_addresses_skips_multiple_known_proxies()
+        public void Proxied_addresses_skips_multiple_known_proxies()
         {
             SetXFF("4.3.2.1, 5.5.5.5, 1.2.3.4, 4.4.4.4");
-            var host = dict.GetRemoteAddresses("1.2.3.4", "5.5.5.5");
+            var host = dict.GetProxiedAddresses("1.2.3.4", "5.5.5.5");
             Assert.That(host, Is.EqualTo(new[] { "4.3.2.1" }));
         }
 
         [Test]
-        public void Remote_addresses_skips_known_proxies_and_returns_multiple_unknown_hops()
+        public void Proxied_addresses_skips_known_proxies_and_returns_multiple_unknown_hops()
         {
             SetXFF("1.1.1.1, 4.3.2.1, 1.2.3.4, 4.4.4.4");
-            var host = dict.GetRemoteAddresses("1.2.3.4");
+            var host = dict.GetProxiedAddresses("1.2.3.4");
             Assert.That(host, Is.EqualTo(new[] { "1.1.1.1", "4.3.2.1" }));
         }
 
         [Test]
-        public void Remote_addresses_skips_multiple_known_proxies_and_returns_multiple_unknown_hops()
+        public void Proxied_addresses_skips_multiple_known_proxies_and_returns_multiple_unknown_hops()
         {
             SetXFF("1.1.1.1, 4.3.2.1, 5.5.5.5, 1.2.3.4, 4.4.4.4");
-            var host = dict.GetRemoteAddresses("1.2.3.4", "5.5.5.5");
+            var host = dict.GetProxiedAddresses("1.2.3.4", "5.5.5.5");
             Assert.That(host, Is.EqualTo(new[] { "1.1.1.1", "4.3.2.1" }));
         }
-    }
+
+        [Test]
+        public void Proxied_addresses_includes_unknown_proxies()
+        {
+            SetXFF("1.1.1.1, 4.3.2.1, 5.5.5.5, 6.6.6.6, 1.2.3.4, 4.4.4.4");
+            var host = dict.GetProxiedAddresses("1.2.3.4", "5.5.5.5");
+            Assert.That(host, Is.EqualTo(new[] { "1.1.1.1", "4.3.2.1", "5.5.5.5", "6.6.6.6" }));
+        }
+	}
 }


### PR DESCRIPTION
No middleware—so maybe this belongs elsewhere—but the idea is how to inspect XFF and pull the directly-connected host out as well as proxied hosts, stopping when an unknown host is encountered.
