### PR TITLE
Middleware to normalization and remove known incoming-proxy addrs

### DIFF
--- a/src/Gate.Middleware/ClientIp.cs
+++ b/src/Gate.Middleware/ClientIp.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Gate.Owin;
+
+namespace Gate.Middleware
+{
+    public static class ClientIp
+    {
+        public static IAppBuilder UseClientIp(this IAppBuilder builder, params string[] knownHttpProxies)
+        {
+            return builder.Use(Middleware, knownHttpProxies);
+        }
+
+        public static AppDelegate Middleware(AppDelegate app, IEnumerable<string> knownHttpProxies)
+        {
+            return (env, result, fault) =>
+            {
+                var req = new Request(env);
+                var clientIp = GetClientIp(req);
+                var forwardedFor = GetForwardedFor(req);
+
+                for (; ; )
+                {
+                    if (clientIp != null && knownHttpProxies.Contains(clientIp))
+                        clientIp = null;
+
+                    if (clientIp != null)
+                        break;
+
+                    if (forwardedFor == null)
+                        break;
+
+                    var finalDelimiter = forwardedFor.LastIndexOfAny(new[] { '\r', '\n', ',' });
+                    clientIp = forwardedFor.Substring(finalDelimiter + 1).Trim();
+                    forwardedFor = finalDelimiter < 1 ? null : forwardedFor.Substring(0, finalDelimiter).Trim();
+                }
+
+                req["server.CLIENT_IP"] = clientIp;
+                if (string.IsNullOrWhiteSpace(forwardedFor))
+                {
+                    if (req.Headers.ContainsKey("X-Forwarded-For"))
+                        req.Headers.Remove("X-Forwarded-For");
+                }
+                else
+                {
+                    req.Headers["X-Forwarded-For"] = forwardedFor;
+                }
+                app(env, result, fault);
+            };
+        }
+
+        static string GetClientIp(IDictionary<string, object> req)
+        {
+            object value;
+            if (req.TryGetValue("server.CLIENT_IP", out value))
+            {
+                var clientIp = Convert.ToString(value);
+                if (!string.IsNullOrWhiteSpace(clientIp))
+                    return clientIp;
+            }
+            return null;
+        }
+
+        static string GetForwardedFor(Request req)
+        {
+            var headers = req.Headers;
+            if (headers == null)
+                return null;
+
+            string forwardedFor;
+            if (headers.TryGetValue("X-Forwarded-For", out forwardedFor))
+            {
+                if (!string.IsNullOrWhiteSpace(forwardedFor))
+                    return forwardedFor;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Gate.Middleware/ForwardedFor.cs
+++ b/src/Gate.Middleware/ForwardedFor.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Gate.Owin;
+
+namespace Gate.Middleware
+{
+    public static class ForwardedFor
+    {
+        public static IAppBuilder UseForwardedFor(this IAppBuilder builder, params string[] knownHttpProxies)
+        {
+            return builder.Use(Middleware, knownHttpProxies);
+        }
+
+        public static AppDelegate Middleware(AppDelegate app, IEnumerable<string> knownHttpProxies)
+        {
+            return (env, result, fault) =>
+            {
+                var req = new Request(env);
+                var clientIp = GetClientIp(req);
+                var forwardedFor = GetForwardedFor(req);
+
+                for (; ; )
+                {
+                    if (clientIp != null && knownHttpProxies.Contains(clientIp))
+                        clientIp = null;
+
+                    if (clientIp != null)
+                        break;
+
+                    if (forwardedFor == null)
+                        break;
+
+                    var finalDelimiter = forwardedFor.LastIndexOfAny(new[] { '\r', '\n', ',' });
+                    clientIp = forwardedFor.Substring(finalDelimiter + 1).Trim();
+                    forwardedFor = finalDelimiter < 1 ? null : forwardedFor.Substring(0, finalDelimiter).Trim();
+                }
+
+                if (clientIp != null && forwardedFor != null)
+                {
+                    forwardedFor = forwardedFor + "," + clientIp;
+                }
+                else 
+                {
+                    forwardedFor = clientIp;
+                }
+
+                if (req.ContainsKey("server.CLIENT_IP"))
+                {
+                    req.Remove("server.CLIENT_IP");
+                }
+                if (string.IsNullOrWhiteSpace(forwardedFor))
+                {
+                    if (req.Headers.ContainsKey("X-Forwarded-For"))
+                        req.Headers.Remove("X-Forwarded-For");
+                }
+                else
+                {
+                    req.Headers["X-Forwarded-For"] = forwardedFor;
+                }
+                app(env, result, fault);
+            };
+        }
+
+        static string GetClientIp(IDictionary<string, object> req)
+        {
+            object value;
+            if (req.TryGetValue("server.CLIENT_IP", out value))
+            {
+                var clientIp = Convert.ToString(value);
+                if (!string.IsNullOrWhiteSpace(clientIp))
+                    return clientIp;
+            }
+            return null;
+        }
+
+        static string GetForwardedFor(Request req)
+        {
+            var headers = req.Headers;
+            if (headers == null)
+                return null;
+
+            string forwardedFor;
+            if (headers.TryGetValue("X-Forwarded-For", out forwardedFor))
+            {
+                if (!string.IsNullOrWhiteSpace(forwardedFor))
+                    return forwardedFor;
+            }
+            return null;
+        }
+    }
+}

--- a/src/Gate.Middleware/Gate.Middleware.csproj
+++ b/src/Gate.Middleware/Gate.Middleware.csproj
@@ -36,6 +36,8 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClientIp.cs" />
+    <Compile Include="ForwardedFor.cs" />
     <Compile Include="MethodOverride.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BasicAuth.cs" />

--- a/src/Tests/Gate.Middleware.Tests/ClientIpTests.cs
+++ b/src/Tests/Gate.Middleware.Tests/ClientIpTests.cs
@@ -1,0 +1,90 @@
+﻿using Gate.TestHelpers;
+using NUnit.Framework;
+
+namespace Gate.Middleware.Tests
+{
+    public class ClientIpTests
+    {
+        static FakeHostResponse CallPipeline(string forwardedFor, string clientIp, params string[] knownHttpProxies)
+        {
+            return AppUtils.CallPipe(
+                builder => builder.Use(ClientIp.Middleware, knownHttpProxies).Run(AppUtils.ShowEnvironment),
+                request =>
+                {
+                    if (clientIp != null)
+                        request["server.CLIENT_IP"] = clientIp;
+                    if (forwardedFor != null)
+                        request.Headers["X-Forwarded-For"] = forwardedFor;
+                });
+        }
+
+        static void AssertResultValues(FakeHostResponse result, string expectedForwardedFor, string expectedClientIp)
+        {
+            var elt = result.BodyXml.Element("server.CLIENT_IP");
+            var clientIp = elt == null ? null : elt.Value;
+
+
+            elt = result.BodyXml.Element("headers").Element("X-Forwarded-For");
+            var forwardedFor = elt == null ? null : elt.Value;
+
+            Assert.That(clientIp, Is.EqualTo(expectedClientIp));
+            Assert.That(forwardedFor, Is.EqualTo(expectedForwardedFor));
+        }
+
+
+        [Test]
+        public void ClientIp_and_ForwardedFor_are_unchanged_when_ClientIp_is_present()
+        {
+            var result = CallPipeline("6.5.7.8, 9.10.11.12", "1.2.3.4");
+            AssertResultValues(result, "6.5.7.8, 9.10.11.12", "1.2.3.4");
+        }
+
+        [Test]
+        public void Missing_ForwardedFor_remains_absent_when_ClientIp_is_present()
+        {
+            var result = CallPipeline(null, "1.2.3.4");
+            AssertResultValues(result, null, "1.2.3.4");
+        }
+
+        [Test]
+        public void Final_component_of_ForwardedFor_becomes_ClientIp_when_absent_empty_or_whitespace()
+        {
+            AssertResultValues(CallPipeline("6.5.7.8, 9.10.11.12", null), "6.5.7.8", "9.10.11.12");
+            AssertResultValues(CallPipeline("6.5.7.8, 9.10.11.12", ""), "6.5.7.8", "9.10.11.12");
+            AssertResultValues(CallPipeline("6.5.7.8, 9.10.11.12", " "), "6.5.7.8", "9.10.11.12");
+        }
+
+        [Test]
+        public void ForwardedFor_is_removed_when_only_value_becomes_ClientIp()
+        {
+            var result = CallPipeline("6.5.7.8", null);
+            AssertResultValues(result, null, "6.5.7.8");
+        }
+
+        [Test]
+        public void Multiple_request_headers_will_also_act_as_delimiter()
+        {
+            var result = CallPipeline("6.5.7.8\r\n9.10.11.12", null);
+            AssertResultValues(result, "6.5.7.8", "9.10.11.12");
+        }
+
+        [Test]
+        public void Known_proxy_address_is_removed_from_client_ip()
+        {
+            var result = CallPipeline("6.5.7.8", "127.0.0.1", "127.0.0.1");
+            AssertResultValues(result, null, "6.5.7.8");
+        }
+        [Test]
+        public void Multiple_proxy_addresses_are_pulled_as_long_as_they_are_recognized()
+        {
+            var result = CallPipeline("6.5.7.8, 9.10.11.12, 13.14.15.16", "127.0.0.1", "127.0.0.1", "9.10.11.12", "13.14.15.16");
+            AssertResultValues(result, null, "6.5.7.8");
+        }
+        [Test]
+        public void Spoofed_remote_ips_are_left_on_the_header_when_supposed_proxies_are_not_recognized()
+        {
+            var result = CallPipeline("255.255.255.255, 6.5.7.8, 9.10.11.12, 13.14.15.16", "127.0.0.1", "127.0.0.1", "9.10.11.12", "13.14.15.16");
+            AssertResultValues(result, "255.255.255.255", "6.5.7.8");
+        }
+    }
+}

--- a/src/Tests/Gate.Middleware.Tests/ForwardedForTests.cs
+++ b/src/Tests/Gate.Middleware.Tests/ForwardedForTests.cs
@@ -1,0 +1,68 @@
+﻿using Gate.TestHelpers;
+using NUnit.Framework;
+
+namespace Gate.Middleware.Tests
+{
+    public class ForwardedForTests
+    {
+        static FakeHostResponse CallPipeline(string forwardedFor, string clientIp, params string[] knownHttpProxies)
+        {
+            return AppUtils.CallPipe(
+                builder => builder.Use(ForwardedFor.Middleware, knownHttpProxies).Run(AppUtils.ShowEnvironment),
+                request =>
+                {
+                    if (clientIp != null)
+                        request["server.CLIENT_IP"] = clientIp;
+                    if (forwardedFor != null)
+                        request.Headers["X-Forwarded-For"] = forwardedFor;
+                });
+        }
+
+        static void AssertResultValues(FakeHostResponse result, string expectedForwardedFor, string expectedClientIp)
+        {
+            var elt = result.BodyXml.Element("server.CLIENT_IP");
+            var clientIp = elt == null ? null : elt.Value;
+
+
+            elt = result.BodyXml.Element("headers").Element("X-Forwarded-For");
+            var forwardedFor = elt == null ? null : elt.Value;
+
+            Assert.That(clientIp, Is.EqualTo(expectedClientIp));
+            Assert.That(forwardedFor, Is.EqualTo(expectedForwardedFor));
+        }
+
+        [Test]
+        public void ClientIp_becomes_ForwardedFor_when_XFF_absent()
+        {
+            var result = CallPipeline(null, "1.2.3.4");
+            AssertResultValues(result, "1.2.3.4", null);
+        }
+
+        [Test]
+        public void ClientIp_added_to_of_forwardedFor_if_XFF_present()
+        {
+            var result = CallPipeline("6.5.7.8, 9.10.11.12", "1.2.3.4");
+            AssertResultValues(result, "6.5.7.8, 9.10.11.12,1.2.3.4", null);
+        }
+
+
+        [Test]
+        public void Known_proxy_address_is_removed_from_client_ip()
+        {
+            var result = CallPipeline("6.5.7.8", "127.0.0.1", "127.0.0.1");
+            AssertResultValues(result, "6.5.7.8", null);
+        }
+        [Test]
+        public void Multiple_proxy_addresses_are_pulled_as_long_as_they_are_recognized()
+        {
+            var result = CallPipeline("6.5.7.8, 9.10.11.12, 13.14.15.16", "127.0.0.1", "127.0.0.1", "9.10.11.12", "13.14.15.16");
+            AssertResultValues(result, "6.5.7.8", null);
+        }
+        [Test]
+        public void Spoofed_remote_ips_are_left_on_the_header_when_supposed_proxies_are_not_recognized()
+        {
+            var result = CallPipeline("255.255.255.255, 6.5.7.8, 9.10.11.12, 13.14.15.16", "127.0.0.1", "127.0.0.1", "9.10.11.12", "13.14.15.16");
+            AssertResultValues(result, "255.255.255.255,6.5.7.8", null);
+        }
+    }
+}

--- a/src/Tests/Gate.Middleware.Tests/Gate.Middleware.Tests.csproj
+++ b/src/Tests/Gate.Middleware.Tests/Gate.Middleware.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -62,6 +62,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ClientIpTests.cs" />
+    <Compile Include="ForwardedForTests.cs" />
     <Compile Include="MethodOverrideTests.cs" />
     <Compile Include="PredicateTests.cs" />
     <Compile Include="BasicAuthTests.cs" />

--- a/src/Tests/Gate.TestHelpers/AppUtils.cs
+++ b/src/Tests/Gate.TestHelpers/AppUtils.cs
@@ -39,6 +39,8 @@ namespace Gate.TestHelpers
                 {
                     var detail = env.Select(kv => new XElement(kv.Key, kv.Value));
                     var xml = new XElement("xml", detail.OfType<object>().ToArray());
+                    var headers = new Request(env).Headers.Select(kv => new XElement(kv.Key, kv.Value));
+                    xml.Add(new XElement("headers", headers.OfType<Object>().ToArray()));
                     response.Write(xml.ToString());
                     complete();
                 });


### PR DESCRIPTION
Normalizes use of server.CLIENT_IP and X-Forwarded-For
Removes known http-proxies, enabling reliable use of either
of the above for client address blocking or logging
