### PR TITLE
Cannot send content when using web api adapter

### DIFF
--- a/src/Adapters/Gate.Adapters.AspNetWebApi/WebApiAdapter.cs
+++ b/src/Adapters/Gate.Adapters.AspNetWebApi/WebApiAdapter.cs
@@ -85,7 +85,14 @@ namespace Gate.Adapters.AspNetWebApi
                     {
                         foreach (var value in kv.Value)
                         {
-                            request.Headers.Add(kv.Key, value);
+                            if (kv.Key.StartsWith("content", StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                request.Content.Headers.Add(kv.Key, value);
+                            }
+                            else
+                            {
+                                request.Headers.Add(kv.Key, value);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Posting some content to an web api action will add headers like Content-Type and Content-Length. When creating a request in the webapiadapter, all request headers are appended to request.Headers. This collection throws an exception when trying to add a content header to it. 

Here is a fix, which adds content headers to the request.Content.Headers instead.
