### PR TITLE
Avoid crash with Kayak when drain is null

### DIFF
--- a/src/Hosts/Gate.Hosts.Kayak/SchedulerMiddleware.cs
+++ b/src/Hosts/Gate.Hosts.Kayak/SchedulerMiddleware.cs
@@ -66,7 +66,7 @@ namespace Gate.Hosts.Kayak
                         {
                             theScheduler.Post(() =>
                             {
-                                if (!flush(() => theScheduler.Post(drained)))
+                                if (!flush(() => if (drained != null) theScheduler.Post(drained)))
                                     if (drained != null) drained.Invoke();
                             });
                             return true;

--- a/src/Hosts/Gate.Hosts.Kayak/SchedulerMiddleware.cs
+++ b/src/Hosts/Gate.Hosts.Kayak/SchedulerMiddleware.cs
@@ -67,7 +67,7 @@ namespace Gate.Hosts.Kayak
                             theScheduler.Post(() =>
                             {
                                 if (!flush(() => theScheduler.Post(drained)))
-                                    drained.Invoke();
+                                    if (drained != null) drained.Invoke();
                             });
                             return true;
                         },


### PR DESCRIPTION
Default stack of:
builder
  .RescheduleCallbacks()
  .RunNancy();

Will crash with NullReferenceException due to drain being null. Adapter should check before invoking.
