### PR TITLE
Fix incorrect delegate syntax

### DIFF
--- a/src/Hosts/Gate.Hosts.Kayak/SchedulerMiddleware.cs
+++ b/src/Hosts/Gate.Hosts.Kayak/SchedulerMiddleware.cs
@@ -66,8 +66,8 @@ namespace Gate.Hosts.Kayak
                         {
                             theScheduler.Post(() =>
                             {
-    							if (!flush(() => { if (drained != null) theScheduler.Post(drained); }))
-                                	if (drained != null) drained.Invoke();
+                                if (!flush(() => { if (drained != null) theScheduler.Post(drained); }))
+                                    if (drained != null) drained.Invoke();
                             });
                             return true;
                         },

--- a/src/Hosts/Gate.Hosts.Kayak/SchedulerMiddleware.cs
+++ b/src/Hosts/Gate.Hosts.Kayak/SchedulerMiddleware.cs
@@ -66,8 +66,8 @@ namespace Gate.Hosts.Kayak
                         {
                             theScheduler.Post(() =>
                             {
-                                if (!flush(() => if (drained != null) theScheduler.Post(drained)))
-                                    if (drained != null) drained.Invoke();
+    							if (!flush(() => { if (drained != null) theScheduler.Post(drained); }))
+                                	if (drained != null) drained.Invoke();
                             });
                             return true;
                         },


### PR DESCRIPTION
This pull request fixes an issue with the delegate code using incorrect syntax in Visual Studio introduced in #77. My apologies for the two commits, there was an issue with whitespace that was fixed in the second commit.
