### PR TITLE
Mark Request and Response with [Serializable] attribute

### DIFF
--- a/src/Main/Gate/Request.cs
+++ b/src/Main/Gate/Request.cs
@@ -11,6 +11,7 @@ using Gate.Utils;
 namespace Gate
 {
     // A helper object for creating, modifying, or consuming request data in an Environment dictionary.
+    [Serializable]
     public struct Request
     {
         IDictionary<string, object> environment;

--- a/src/Main/Gate/Response.cs
+++ b/src/Main/Gate/Response.cs
@@ -11,6 +11,7 @@ using System.Threading;
 namespace Gate
 {
     // A helper object for creating, modifying, or consuming response data in the Environment dictionary.
+    [Serializable]
     public struct Response
     {
         public Response(IDictionary<string, object> environment)

--- a/src/Tests/Gate.Tests/RequestTests.cs
+++ b/src/Tests/Gate.Tests/RequestTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using NUnit.Framework;
 using Owin;
 using System.Threading;
@@ -448,6 +450,14 @@ namespace Gate.Tests
             Assert.That(req.HostWithPort, Is.EqualTo("[2001:db8::ff00:42:8329]:54321"));
             Assert.That(req.Host, Is.EqualTo("2001:db8::ff00:42:8329"));
             Assert.That(req.Port, Is.EqualTo(54321));
+        }
+
+        [Test]
+        public void IsSerializable()
+        {
+            var request = new Request(CreateEmptyEnvironment());
+            var serializer = new BinaryFormatter();
+            Assert.DoesNotThrow(() => serializer.Serialize(new MemoryStream(), request));
         }
     }
 }

--- a/src/Tests/Gate.Tests/RequestTests.cs
+++ b/src/Tests/Gate.Tests/RequestTests.cs
@@ -453,7 +453,7 @@ namespace Gate.Tests
         }
 
         [Test]
-        public void IsSerializable()
+        public void ItShouldBeSerializable()
         {
             var request = new Request(CreateEmptyEnvironment());
             var serializer = new BinaryFormatter();

--- a/src/Tests/Gate.Tests/ResponseTests.cs
+++ b/src/Tests/Gate.Tests/ResponseTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -159,6 +160,14 @@ namespace Gate.Tests
                 "foo=bar; path=/",
                 "foo=; path=/path; expires=Thu, 01-Jan-1970 00:00:00 GMT"
             }));
+        }
+
+        [Test]
+        public void ItShouldBeSerializable()
+        {
+            var response = new Response(CreateEmptyEnvironment());
+            var serializer = new BinaryFormatter();
+            Assert.DoesNotThrow(() => serializer.Serialize(new MemoryStream(), response));
         }
     }
 }


### PR DESCRIPTION
Includes tests.
